### PR TITLE
Add GitHub environment for PyPI trusted publisher - Create pypi envir…

### DIFF
--- a/.github/environments/pypi.yml
+++ b/.github/environments/pypi.yml
@@ -1,0 +1,1 @@
+name: pypi 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -11,6 +11,7 @@ jobs:
   publish-python:
     name: Publish Python Package to PyPI
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       contents: read
       packages: write
@@ -52,6 +53,5 @@ jobs:
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
         packages-dir: rust/python_bindings/target/wheels/
         skip-existing: true 


### PR DESCRIPTION
…onment configuration - Update workflow to use trusted publisher instead of API token - Ready for PyPI trusted publisher setup