### PR TITLE
Fix PyPI: build wheels for Python 3.9, 3.10, 3.11, 3.12

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -18,6 +18,9 @@ jobs:
       contents: read
       packages: write
       id-token: write
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     
     steps:
     - uses: actions/checkout@v4
@@ -34,7 +37,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: ${{ matrix.python-version }}
     
     - name: Install uv
       uses: astral-sh/setup-uv@v1
@@ -45,7 +48,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: rust/python_bindings/.venv
-        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('rust/python_bindings/uv.lock') }}
+        key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('rust/python_bindings/uv.lock') }}
     
     - name: Install dependencies
       run: cd rust/python_bindings && uv sync


### PR DESCRIPTION
- Add matrix strategy to build for multiple Python versions
- Update Python setup to use matrix version
- Update cache key to include Python version
- Fixes 'No matching distribution' error for Python 3.12 users

# 🚨 REQUIRED: Please fill out this template completely

## Description

**⚠️ This section is required and must be filled out completely.**

Please provide a detailed description of the work completed in this PR. Include:
- What was changed
- Why it was changed  
- Any important context or decisions made

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change
- [ ] Performance improvement
- [ ] Refactoring

## Complexity

- [ ] LOW
- [ ] MEDIUM
- [ ] HIGH

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Performance tests

## Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] Integration tests have been updated
- [ ] Python bindings tested
- [ ] JavaScript bindings tested
- [ ] Rust tests passing
- [ ] CHANGELOG.md updated if appropriate
- [ ] Breaking changes documented

## Release Notes

<!-- Optional: Provide a brief summary for release notes -->

## Additional Notes

Deploying multiple versions of the package in different python runtimes to pypi PyPI 