### PR TITLE
Remove Python 3.9 support - EOL as of October 2025

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -20,7 +20,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
- Update PyPI matrix to only build for Python 3.10, 3.11, 3.12
- Python 3.9 is end-of-life and causes PyO3 compatibility issues
- Focus on supported Python versions only

# 🚨 REQUIRED: Please fill out this template completely

## Description

**⚠️ This section is required and must be filled out completely.**

Please provide a detailed description of the work completed in this PR. Include:
- What was changed
- Why it was changed  
- Any important context or decisions made

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change
- [ ] Performance improvement
- [ ] Refactoring

## Complexity

- [ ] LOW
- [ ] MEDIUM
- [ ] HIGH

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Performance tests

## Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] Integration tests have been updated
- [ ] Python bindings tested
- [ ] JavaScript bindings tested
- [ ] Rust tests passing
- [ ] CHANGELOG.md updated if appropriate
- [ ] Breaking changes documented

## Release Notes

<!-- Optional: Provide a brief summary for release notes -->

## Additional Notes

<!-- Any additional information, context, or considerations -->
