### PR TITLE
Remove `is_read` function from Python bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Streamlined README to focus on user installation
 - Moved development details to separate docs/DEVELOPMENT.md
 - Enhanced PARSER_INTERNALS.md with real code examples
+- Removed `is_read` function since this duplicates `is_write` functionality
 - Removed `from_json_string` method from `DbSchema` object
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ let errors = validate_cypher_with_schema(query, &schema)?;
 - **`validate_cypher(query, schema)`** - Returns list of validation errors
 - **`check_syntax(query)`** - Check syntax only (no schema needed)
 - **`is_write(query)`** - Check if query modifies data
-- **`is_read(query)`** - Check if query is read-only
 - **`has_parser_errors(query)`** - Check if query has syntax errors
 
 ### Schema Classes

--- a/rust/python_bindings/tests/unit/test_parser_errors.py
+++ b/rust/python_bindings/tests/unit/test_parser_errors.py
@@ -215,7 +215,6 @@ class TestErrorConsistency:
         error_raising_functions = [
             cypher_guard.check_syntax,
             lambda q: cypher_guard.is_write(q),
-            lambda q: cypher_guard.is_read(q),
         ]
 
         for func in error_raising_functions:
@@ -234,7 +233,6 @@ class TestErrorConsistency:
         error_raising_functions = [
             cypher_guard.check_syntax,
             lambda q: cypher_guard.is_write(q),
-            lambda q: cypher_guard.is_read(q),
         ]
 
         for func in error_raising_functions:


### PR DESCRIPTION
# 🚨 REQUIRED: Please fill out this template completely

## Description

Remove `is_read` function from Python bindings. This function duplicates functionality of the `is_write` function and duplicates code. The user interface is now cleaner.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [x] Breaking change
- [ ] Documentation update
- [ ] Project configuration change
- [ ] Performance improvement
- [x] Refactoring

## Complexity

- [x] LOW
- [ ] MEDIUM
- [ ] HIGH

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Performance tests

## Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] Unit tests have been updated
- [ ] Integration tests have been updated
- [x] Python bindings tested
- [ ] JavaScript bindings tested
- [x] Rust tests passing
- [x] CHANGELOG.md updated if appropriate
- [ ] Breaking changes documented
