### PR TITLE
add from_components and from_map constructors to DbSchema - rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - PR template for structured PR descriptions
 - GitHub Action for automatic release note generation
+- Add `from_components` and `from_map` functions to `DbSchema` 
 
 ### Changed
 - Streamlined README to focus on user installation

--- a/rust/cypher_guard/src/schema.rs
+++ b/rust/cypher_guard/src/schema.rs
@@ -846,9 +846,7 @@ mod tests {
         );
 
         let relationships = vec![DbSchemaRelationshipPattern::new(
-            "Person",
-            "Person",
-            "KNOWS",
+            "Person", "Person", "KNOWS",
         )];
 
         let metadata = DbSchemaMetadata::new();


### PR DESCRIPTION
`from_components` and `from_map` functions on `DbSchema` object allow construction with existing node and relationship values. This will improve the user interface and make handling these objects simpler. 

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change
- [ ] Performance improvement
- [ ] Refactoring

## Complexity

- [x] LOW
- [ ] MEDIUM
- [ ] HIGH

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Performance tests

## Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] Integration tests have been updated
- [ ] Python bindings tested
- [ ] JavaScript bindings tested
- [x] Rust tests passing
- [x] CHANGELOG.md updated if appropriate
- [ ] Breaking changes documented
