### PR TITLE
feat: implement INSERT clause support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - PR template for structured PR descriptions
 - GitHub Action for automatic release note generation
-- Add `from_components` and `from_map` functions to `DbSchema` 
+- Add `from_components` and `from_map` functions to `DbSchema`
+- INSERT clause support (Cypher 5.18, GQL conformance)
+  - Parser support for INSERT clause with &-separated labels
+  - Validation support for INSERT clauses
+  - Comprehensive test coverage 
 
 ### Changed
 - Streamlined README to focus on user installation

--- a/docs/PARSER_INTERNALS.md
+++ b/docs/PARSER_INTERNALS.md
@@ -110,6 +110,7 @@ The parser distinguishes between different levels of errors:
 - `WITH` (aliases, property access, function calls, wildcards)
 - `WHERE` (complex conditions, logical operators, parentheses)
 - `CREATE`
+- `INSERT` (Cypher 5.18, GQL conformance, uses `&` for multiple labels)
 - `MERGE` (with `ON CREATE` and `ON MATCH`)
 - `SET`
 
@@ -206,6 +207,7 @@ pub struct Query {
     pub match_clauses: Vec<MatchClause>,
     pub merge_clauses: Vec<MergeClause>,
     pub create_clauses: Vec<CreateClause>,
+    pub insert_clauses: Vec<InsertClause>,
     pub with_clauses: Vec<WithClause>,
     pub where_clauses: Vec<WhereClause>,
     pub return_clauses: Vec<ReturnClause>,

--- a/rust/cypher_guard/src/parser/ast.rs
+++ b/rust/cypher_guard/src/parser/ast.rs
@@ -4,6 +4,7 @@ pub struct Query {
     pub match_clauses: Vec<MatchClause>,
     pub merge_clauses: Vec<MergeClause>,
     pub create_clauses: Vec<CreateClause>,
+    pub insert_clauses: Vec<InsertClause>,
     pub with_clauses: Vec<WithClause>,
     pub where_clauses: Vec<WhereClause>,
     pub return_clauses: Vec<ReturnClause>,
@@ -194,6 +195,12 @@ pub struct MergeClause {
 // CREATE clause
 #[derive(Debug, PartialEq, Clone)]
 pub struct CreateClause {
+    pub elements: Vec<MatchElement>,
+}
+
+// INSERT clause (synonym for CREATE, but uses & for multiple labels)
+#[derive(Debug, PartialEq, Clone)]
+pub struct InsertClause {
     pub elements: Vec<MatchElement>,
 }
 


### PR DESCRIPTION
- Add InsertClause to AST (ast.rs)
- Implement INSERT clause parser with &-separated labels (clauses.rs, patterns.rs)
- Add node_pattern_insert parser for INSERT-specific label syntax
- Update clause order validation to treat INSERT like CREATE/MERGE
- Add validation extraction for INSERT clauses
- Add comprehensive test coverage:
  * Single and multiple labels with & separator
  * Node properties
  * Relationships with properties
  * Multiple INSERT clauses
  * Clause order validation
  * Validation extraction tests

INSERT clause functions as synonym for CREATE but requires & for multiple labels instead of : and does not support dynamic labels/types. Introduced in Cypher 5.18 for GQL conformance.

# 🚨 REQUIRED: Please fill out this template completely

## Description

**⚠️ This section is required and must be filled out completely.**

Please provide a detailed description of the work completed in this PR. Include:
- What was changed
- Why it was changed  
- Any important context or decisions made

## Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change
- [ ] Performance improvement
- [ ] Refactoring

## Complexity

- [ ] LOW
- [X] MEDIUM
- [ ] HIGH

## How Has This Been Tested?

- [X] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Performance tests

## Checklist

The following requirements should have been met (depending on the changes in the branch):

- [X] Documentation has been updated
- [X] Unit tests have been updated
- [ ] Integration tests have been updated
- [ ] Python bindings tested
- [ ] JavaScript bindings tested
- [X] Rust tests passing
- [X] CHANGELOG.md updated if appropriate
- [ ] Breaking changes documented

## Release Notes



## Additional Notes


