### PR TITLE
Feat 67/delete clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - PR template for structured PR descriptions
 - GitHub Action for automatic release note generation
-- Add `from_components` and `from_map` functions to `DbSchema` 
+- Add `from_components` and `from_map` functions to `DbSchema`
+- DELETE clause support (Cypher 5.14+) 
 
 ### Changed
 - Streamlined README to focus on user installation

--- a/docs/PARSER_INTERNALS.md
+++ b/docs/PARSER_INTERNALS.md
@@ -111,6 +111,7 @@ The parser distinguishes between different levels of errors:
 - `WHERE` (complex conditions, logical operators, parentheses)
 - `CREATE`
 - `MERGE` (with `ON CREATE` and `ON MATCH`)
+- `DELETE` (Cypher 5.14+)
 - `SET`
 
 ### Node Patterns
@@ -206,6 +207,7 @@ pub struct Query {
     pub match_clauses: Vec<MatchClause>,
     pub merge_clauses: Vec<MergeClause>,
     pub create_clauses: Vec<CreateClause>,
+    pub delete_clauses: Vec<DeleteClause>,
     pub with_clauses: Vec<WithClause>,
     pub where_clauses: Vec<WhereClause>,
     pub return_clauses: Vec<ReturnClause>,
@@ -237,6 +239,18 @@ pub struct ReturnClause {
     pub items: Vec<String>, // Simplified for validation
 }
 ```
+
+#### DeleteClause
+```rust
+#[derive(Debug, PartialEq, Clone)]
+pub struct DeleteClause {
+    pub targets: Vec<String>, // Variables to delete (nodes, relationships, paths)
+}
+```
+
+The DELETE clause deletes nodes, relationships, or paths by referencing their variables. Example: `DELETE n, r` deletes the node bound to `n` and the relationship bound to `r`.
+
+**Note**: DELETE follows the same clause ordering rules as CREATE and MERGE (writing clauses). Variables being deleted must be defined in a previous clause (e.g., MATCH).
 
 #### WhereClause
 ```rust

--- a/rust/cypher_guard/src/parser/ast.rs
+++ b/rust/cypher_guard/src/parser/ast.rs
@@ -4,6 +4,7 @@ pub struct Query {
     pub match_clauses: Vec<MatchClause>,
     pub merge_clauses: Vec<MergeClause>,
     pub create_clauses: Vec<CreateClause>,
+    pub delete_clauses: Vec<DeleteClause>,
     pub with_clauses: Vec<WithClause>,
     pub where_clauses: Vec<WhereClause>,
     pub return_clauses: Vec<ReturnClause>,
@@ -195,6 +196,12 @@ pub struct MergeClause {
 #[derive(Debug, PartialEq, Clone)]
 pub struct CreateClause {
     pub elements: Vec<MatchElement>,
+}
+
+// DELETE clause - deletes nodes, relationships, or paths
+#[derive(Debug, PartialEq, Clone)]
+pub struct DeleteClause {
+    pub targets: Vec<String>, // Variables to delete (nodes, relationships, paths)
 }
 
 // ON CREATE clause


### PR DESCRIPTION
# 🚨 REQUIRED: Please fill out this template completely

## Description

## Summary

Implements support for the `DELETE` clause in Cypher queries (Cypher 5.14+). The DELETE clause allows deleting nodes, relationships, or paths by referencing their variables.

## Changes

### Parser & AST
- Added `DeleteClause` struct to AST with `targets: Vec<String>` field
- Added `delete_clauses: Vec<DeleteClause>` to `Query` struct
- Implemented `delete_clause` parser function that parses comma-separated variable targets
- Added `Delete` variant to `Clause` enum
- Integrated DELETE into clause dispatcher and query assembly

### Clause Order Validation
- DELETE follows the same clause ordering rules as CREATE and MERGE (writing clauses)
- Can appear after MATCH, UNWIND, WHERE, WITH, or at query start
- Can appear after RETURN (writing clauses are allowed after RETURN)
- Cannot appear after another writing clause without WITH or RETURN in between

### Validation
- Added DELETE clause extraction in `extract_query_elements()`
- Tracks DELETE variables separately for explicit validation
- Validates that variables being deleted are defined (from MATCH, etc.)
- Validates that variables being deleted are bound to valid node labels (if bound to nodes)
- Validates that variables being deleted are bound to valid relationship types (if bound to relationships)

### Error Handling
- Added `DeleteAfterReturn` error variant to `CypherGuardParsingError`
- Added DELETE error handling to Python bindings
- Added DELETE error handling to JavaScript/TypeScript bindings

### Tests
- Added unit tests for DELETE clause parsing (single and multiple variables)
- Added clause order validation tests for DELETE
- Added validation tests for DELETE with undefined variables
- Added validation tests for DELETE with invalid node labels
- Added validation tests for DELETE with invalid relationship types
- Added multi-line query tests with multiple MATCH and DELETE clauses

### Documentation
- Updated `CHANGELOG.md` with DELETE clause support
- Updated `PARSER_INTERNALS.md` with DELETE clause documentation
- Added DELETE to supported clauses list
- Added `DeleteClause` structure documentation

## Example Usage

```cypher
// Delete a single node
MATCH (n:Person {name: 'Tom Hanks'})
DELETE n

// Delete multiple variables
MATCH (n:Person)-[r:ACTED_IN]->(m:Movie)
DELETE n, r

// Delete after RETURN
MATCH (n:Person)
RETURN n
DELETE n
```

## Testing

All tests pass:
- 18 DELETE-related unit tests
- Clause order validation tests
- Variable validation tests
- Label/type validation tests

## Related Issues

Closes #67

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change
- [ ] Performance improvement
- [ ] Refactoring

## Complexity

- [ ] LOW
- [x] MEDIUM
- [ ] HIGH

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Performance tests

## Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] Unit tests have been updated
- [ ] Integration tests have been updated
- [ ] Python bindings tested
- [ ] JavaScript bindings tested
- [x] Rust tests passing
- [x] CHANGELOG.md updated if appropriate
- [ ] Breaking changes documented

## Release Notes


## Additional Notes

