### PR TITLE
Feat 74/limit clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - PR template for structured PR descriptions
 - GitHub Action for automatic release note generation
-- Add `from_components` and `from_map` functions to `DbSchema` 
+- Add `from_components` and `from_map` functions to `DbSchema`
+- LIMIT clause support (Cypher 5.24+) 
 
 ### Changed
 - Streamlined README to focus on user installation

--- a/docs/PARSER_INTERNALS.md
+++ b/docs/PARSER_INTERNALS.md
@@ -112,6 +112,7 @@ The parser distinguishes between different levels of errors:
 - `CREATE`
 - `MERGE` (with `ON CREATE` and `ON MATCH`)
 - `SET`
+- `LIMIT` (Cypher 5.24+)
 
 ### Node Patterns
 - Basic nodes: `(n)`
@@ -211,6 +212,7 @@ pub struct Query {
     pub return_clauses: Vec<ReturnClause>,
     pub unwind_clauses: Vec<UnwindClause>,
     pub call_clauses: Vec<CallClause>,
+    pub limit_clauses: Vec<LimitClause>,
 }
 ```
 
@@ -237,6 +239,20 @@ pub struct ReturnClause {
     pub items: Vec<String>, // Simplified for validation
 }
 ```
+
+#### LimitClause
+```rust
+#[derive(Debug, PartialEq, Clone)]
+pub struct LimitClause {
+    pub expression: PropertyValue, // Expression that evaluates to a positive INTEGER
+}
+```
+
+The `LIMIT` clause constrains the number of returned rows. It can be used:
+- As a standalone clause after `MATCH` (Cypher 5.24+): `MATCH (n) LIMIT 2 RETURN collect(n.name)`
+- After `RETURN` clause (traditional): `MATCH (n) RETURN n.name LIMIT 3`
+
+Currently, `LIMIT` supports numeric literals and parameters. Function calls and arithmetic expressions are not yet supported.
 
 #### WhereClause
 ```rust

--- a/rust/cypher_guard/src/parser/ast.rs
+++ b/rust/cypher_guard/src/parser/ast.rs
@@ -9,6 +9,7 @@ pub struct Query {
     pub return_clauses: Vec<ReturnClause>,
     pub unwind_clauses: Vec<UnwindClause>,
     pub call_clauses: Vec<CallClause>,
+    pub limit_clauses: Vec<LimitClause>,
 }
 
 // RETURN clause (simple)
@@ -265,4 +266,10 @@ pub struct CallClause {
     pub subquery: Option<Query>,           // For CALL { ... } subqueries
     pub procedure: Option<String>,         // For CALL procedure() calls
     pub yield_clause: Option<Vec<String>>, // For YIELD clause
+}
+
+// LIMIT clause
+#[derive(Debug, PartialEq, Clone)]
+pub struct LimitClause {
+    pub expression: PropertyValue, // Expression that evaluates to a positive INTEGER
 }

--- a/rust/cypher_guard/src/parser/patterns.rs
+++ b/rust/cypher_guard/src/parser/patterns.rs
@@ -172,6 +172,7 @@ pub fn pattern_element_sequence(
             || trimmed_input.starts_with("REMOVE")
             || trimmed_input.starts_with("SET")
             || trimmed_input.starts_with("MERGE")
+            || trimmed_input.starts_with("LIMIT")
         {
             println!(
                 "[pattern_element_sequence] Stopping at clause boundary: '{}'",

--- a/rust/cypher_guard/src/validation.rs
+++ b/rust/cypher_guard/src/validation.rs
@@ -870,6 +870,7 @@ mod tests {
             return_clauses: vec![],
             unwind_clauses: vec![],
             call_clauses: vec![],
+            limit_clauses: vec![],
         };
 
         let elements = extract_query_elements(&query);
@@ -906,6 +907,7 @@ mod tests {
             return_clauses: vec![],
             unwind_clauses: vec![],
             call_clauses: vec![],
+            limit_clauses: vec![],
         };
 
         let elements = extract_query_elements(&query);
@@ -944,6 +946,7 @@ mod tests {
             }],
             unwind_clauses: vec![],
             call_clauses: vec![],
+            limit_clauses: vec![],
         };
 
         let elements = extract_query_elements(&query);
@@ -989,6 +992,7 @@ mod tests {
             return_clauses: vec![],
             unwind_clauses: vec![],
             call_clauses: vec![],
+            limit_clauses: vec![],
         };
 
         let elements = extract_query_elements(&query);
@@ -1021,6 +1025,7 @@ mod tests {
                 variable: "x".to_string(),
             }],
             call_clauses: vec![],
+            limit_clauses: vec![],
         };
         let elements = extract_query_elements(&query);
         assert!(elements.defined_variables.contains("x"));
@@ -1276,6 +1281,7 @@ mod tests {
                 variable: "x".to_string(),
             }],
             call_clauses: vec![],
+            limit_clauses: vec![],
         };
         let elements = QueryElements::new();
         let schema = DbSchema::new();
@@ -1353,6 +1359,7 @@ mod tests {
             return_clauses: vec![],
             unwind_clauses: vec![],
             call_clauses: vec![],
+            limit_clauses: vec![],
         };
 
         let elements = extract_query_elements(&valid_query);
@@ -1402,6 +1409,7 @@ mod tests {
             return_clauses: vec![],
             unwind_clauses: vec![],
             call_clauses: vec![],
+            limit_clauses: vec![],
         };
 
         let elements = extract_query_elements(&invalid_query);


### PR DESCRIPTION
# 🚨 REQUIRED: Please fill out this template completely

Add LIMIT Clause Support (Cypher 5.24+)
This PR adds support for the LIMIT clause in Cypher queries, following the Neo4j 5.24+ specification.

Changes
AST Changes: Added LimitClause struct with PropertyValue expression field
Parser: Implemented limit_clause parser function supporting numeric literals and parameters
Clause Order Validation: Added LIMIT to clause order state machine

LIMIT can appear as standalone clause after MATCH (5.24+)
LIMIT can appear after RETURN clause (traditional usage)
Integration: Added LIMIT to clause dispatcher and pattern boundary checks

Tests: Added tests for LIMIT parsing and clause order validation

Documentation: Updated CHANGELOG.md and PARSER_INTERNALS.md

Limitations
Currently supports numeric literals and parameters only
Function calls (e.g., LIMIT toInteger(3 * rand())) are not yet supported
Arithmetic expressions (e.g., LIMIT 1 + 2) are not yet supported
These will be added when full expression parsing is implemented.




## Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change
- [ ] Performance improvement
- [ ] Refactoring

## Complexity

- [ ] LOW
- [X] MEDIUM
- [ ] HIGH

## How Has This Been Tested?

- [X] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Performance tests

## Checklist

The following requirements should have been met (depending on the changes in the branch):

- [X] Documentation has been updated
- [X] Unit tests have been updated
- [ ] Integration tests have been updated
- [ ] Python bindings tested
- [ ] JavaScript bindings tested
- [X] Rust tests passing
- [X] CHANGELOG.md updated if appropriate
- [ ] Breaking changes documented

## Release Notes


## Additional Notes

